### PR TITLE
Fix missing dev dependency for: sinatra

### DIFF
--- a/sidekiq-prioritized_queues.gemspec
+++ b/sidekiq-prioritized_queues.gemspec
@@ -23,4 +23,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.7"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "minitest"
+  spec.add_development_dependency "sinatra"
 end


### PR DESCRIPTION
- Seems it went unnoticed that Sinatra was missing to be able to run specs