### PR TITLE
Fix bulk re-queue when more than 1 job is running

### DIFF
--- a/lib/sidekiq/prioritized_queues/fetch.rb
+++ b/lib/sidekiq/prioritized_queues/fetch.rb
@@ -66,9 +66,11 @@ module Sidekiq
         end
 
         Sidekiq.redis do |conn|
-          conn.pipelined do
+          conn.pipelined do |pipeline|
             jobs_to_requeue.each do |queue, jobs|
-              conn.zadd(queue, 0, jobs)
+              jobs.each do |job|
+                pipeline.zadd(queue, 0, job)
+              end
             end
           end
         end


### PR DESCRIPTION
Merging [Fix bulk re-queue when more than 1 job is running](https://github.com/publitas/sidekiq-prioritized_queues/pull/6) #6